### PR TITLE
Move hamcrest library to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.2.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I noticed the hamcrest library was seeping into the dependencies. I have added the test scope to the dependency of the hamcrest library.
