### PR TITLE
replace deprecated jinjava-maven-plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,9 @@ Obtain an `IBAN` instance using one of the static factory methods: `valueOf( )` 
 
 ### Version History
 
+#### Unreleased
+* Removes `@Generated` annotation from `CountryCodesData` class to avoid having a runtime dependency on newer JDK's.
+
 #### 1.8.0: 21 November 2020
 * The `IBAN` class implements `java.io.Serializable` ([#23][i23]). The serialized form should stay valid across library
   version updates. There is one obvious backwards-incompatibility: deserializing after a version downgrade, of an IBAN

--- a/pom.xml
+++ b/pom.xml
@@ -98,15 +98,15 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>jinjava-maven-plugin</artifactId>
-                <groupId>com.github.terefang</groupId>
-                <version>2020.5.4</version>
+                <artifactId>template-maven-plugin</artifactId>
+                <groupId>com.github.terefang.template</groupId>
+                <version>2021.4.19</version>
                 <executions>
                     <execution>
                         <id>generate-code</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <goal>jinjava</goal>
+                            <goal>jinjava-standard</goal>
                         </goals>
                         <configuration>
                             <additionalContext>src/main/resources/nl/garvelink/iban/IBAN.yml</additionalContext>
@@ -115,6 +115,13 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.hubspot.jinjava</groupId>
+                        <artifactId>jinjava</artifactId>
+                        <version>2.5.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -145,7 +152,6 @@
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
-                        <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/src/main/jinjava/nl/garvelink/iban/CountryCodesData.java.j2
+++ b/src/main/jinjava/nl/garvelink/iban/CountryCodesData.java.j2
@@ -15,7 +15,6 @@
  */
 package nl.garvelink.iban;
 
-import javax.annotation.Generated;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,7 +23,6 @@ import java.util.Collections;
  * Contains information about IBAN country codes. This is a generated file.
  * Updated to SWIFT IBAN Registry version {{ context.meta.iban_registry_version | escape }} on {{ context.meta.last_update | datetimeformat("%Y-%m-%d") | escape }}.
  */
-@Generated("com.github.terefang.jinjava-maven-plugin")
 abstract class CountryCodesData {
     /**
      * The "yyyy-MM-dd" datestamp that the embedded IBAN data was updated.


### PR DESCRIPTION
- Upstream was changed to template-maven-plugin: https://github.com/terefang/template
- Override plugin's Jinjava dependency to a newer build that runs in JDK 11
- Remove `-Werror` so as not to have to juggle bootstrap classpath during build
- Remove `@Generated` because it moved to a library in JDK11, and I don't want  to have a silly runtime dependency.