### PR TITLE
Lint fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updates to IBAN Registry revision 97
     * Falkland Islands (FK): added
     * Oman (OM): added
+* Bug fix: non-serializable instance field in `IBANException`.
 
 ## 1.14.0: 18 May 2023
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,7 @@ Obtain an `IBAN` instance using one of the static factory methods: `valueOf( )` 
 * Updates to IBAN Registry revision 97
     * Falkland Islands (FK): added
     * Oman (OM): added
+* Bug fix: non-serializable instance field in `IBANException`.
 
 ## 1.14.0: 18 May 2023
 

--- a/src/main/java/nl/garvelink/iban/IBANException.java
+++ b/src/main/java/nl/garvelink/iban/IBANException.java
@@ -20,11 +20,11 @@ package nl.garvelink.iban;
  */
 public abstract class IBANException extends IllegalArgumentException {
     private static final long serialVersionUID = 1L;
-    private final CharSequence failedInput;
+    private final String failedInput;
 
     public IBANException(String message, CharSequence failedInput) {
         super(message);
-        this.failedInput = failedInput;
+        this.failedInput = failedInput == null ? null : failedInput.toString();
     }
 
     /**

--- a/src/main/java/nl/garvelink/iban/IBANException.java
+++ b/src/main/java/nl/garvelink/iban/IBANException.java
@@ -20,9 +20,10 @@ package nl.garvelink.iban;
  */
 public abstract class IBANException extends IllegalArgumentException {
     private static final long serialVersionUID = 1L;
+    /** The erroneous input. */
     private final String failedInput;
 
-    public IBANException(String message, CharSequence failedInput) {
+    IBANException(String message, CharSequence failedInput) {
         super(message);
         this.failedInput = failedInput == null ? null : failedInput.toString();
     }

--- a/src/main/java/nl/garvelink/iban/IBANParseException.java
+++ b/src/main/java/nl/garvelink/iban/IBANParseException.java
@@ -21,7 +21,7 @@ package nl.garvelink.iban;
 public class IBANParseException extends IBANException {
     private static final long serialVersionUID = 1L;
 
-    public IBANParseException(String message, CharSequence failedInput) {
+    IBANParseException(String message, CharSequence failedInput) {
         super(message, failedInput);
     }
 }

--- a/src/main/java/nl/garvelink/iban/WrongLengthException.java
+++ b/src/main/java/nl/garvelink/iban/WrongLengthException.java
@@ -20,7 +20,9 @@ package nl.garvelink.iban;
  */
 public class WrongLengthException extends IBANException {
     private static final long serialVersionUID = 2L;
+    /** Actual length of input. */
     private final int actualLength;
+    /** Expected length of input. */
     private final int expectedLength;
 
     WrongLengthException(String failedInput, int expectedLength) {
@@ -30,10 +32,18 @@ public class WrongLengthException extends IBANException {
         this.expectedLength = expectedLength;
     }
 
+    /**
+     * The expected length for the input, given its country code.
+     * @return expected length of country IBAN.
+     */
     public int getExpectedLength() {
         return expectedLength;
     }
 
+    /**
+     * The actual length of the input IBAN.
+     * @return length of {@link #getFailedInput()}.
+     */
     public int getActualLength() {
         return actualLength;
     }


### PR DESCRIPTION
- Correctness: non-serializable instance field in `IBANException`.
- Missing Javadoc headers.